### PR TITLE
Matching if the chunk has the same size as the delimiter

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -61,7 +61,7 @@ class StreamSplit extends Transform {
         chunk = Buffer.concat([lastChunk, chunk], len);
       }
 
-      const idx = (delimiter && delimiter.length < chunk.length ? chunk.indexOf(delimiter) : -1);
+      const idx = (delimiter && delimiter.length <= chunk.length ? chunk.indexOf(delimiter) : -1);
 
       if (idx !== -1) {
         const firstChunk = chunk.slice(0, idx);


### PR DESCRIPTION
My networking code happens to send the delimiter with a slight delay. This leads to a chunk in which the delimiter is the only content and could not be matched. This fixed it.